### PR TITLE
- Remove opener in `window.open`

### DIFF
--- a/util/client.js
+++ b/util/client.js
@@ -33,6 +33,6 @@ export function openURL(vue, url, name, specs, replace) {
   if (checkIsTrustClient(vue)) {
     window.location.assign(url);
   } else {
-    window.open(url, name || '_blank', specs, replace);
+    window.open(url, name || '_blank', specs, replace).opener = null;
   }
 }


### PR DESCRIPTION
source
https://stackoverflow.com/questions/49276569/window-open-with-noopener-opens-a-new-window-instead-of-a-new-tab