### PR TITLE
Revert "⚡️ Add authcore swagger preload in register page"

### DIFF
--- a/pages/in/register/index.vue
+++ b/pages/in/register/index.vue
@@ -5,7 +5,6 @@
 <script>
 import { mapActions, mapGetters } from 'vuex';
 import { tryPostLoginRedirect, isIOS } from '~/util/client';
-import { AUTHCORE_API_HOST } from '~/constant';
 
 import { logTrackerEvent, logTimingEvent } from '@/util/EventLogger';
 
@@ -31,9 +30,6 @@ export default {
           property: 'og:description',
           content: this.$t('Register.header.title'),
         },
-      ],
-      link: [
-        { rel: 'preload', href: `${AUTHCORE_API_HOST}/api/authapi/authcore.swagger.json` },
       ],
     };
   },


### PR DESCRIPTION
Reverts likecoin/likecoin-store#1315
Couldnt figure out how to make chrome use the preload / prefetched cache for XHR json, reverting